### PR TITLE
fx: audio playing on dialog close

### DIFF
--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -8,7 +8,7 @@
     import { PauseIcon, PlayIcon } from 'lucide-svelte';
     import { onDestroy } from 'svelte';
 
-    let { settings = $bindable() }: { settings: Settings } = $props();
+    let { settings = $bindable(), open = $bindable() }: { settings: Settings; open: boolean } = $props();
 
     let x = $state([settings.volume]);
     $effect(() => {
@@ -43,15 +43,21 @@
         }
     });
 
+    // Stop audio when dialog closes
+    $effect(() => {
+        if (!open && playing) {
+            audio.pause();
+            playing = false;
+        }
+    });
+
     const toggle_sound = () => {
         if (playing) {
             audio.pause();
             playing = false;
-            console.log('stopped audio');
         } else {
             audio.play();
             playing = true;
-            console.log('started audio', audio);
         }
     };
 

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -50,14 +50,16 @@
             playing = false;
         }
     });
-
+    
     const toggle_sound = () => {
         if (playing) {
             audio.pause();
             playing = false;
+            console.log('stopped audio');
         } else {
             audio.play();
             playing = true;
+            console.log('started audio', audio);
         }
     };
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -253,7 +253,7 @@
 </AlertDialog.Root>
 
 <Dialog.Root bind:open={settings_open}>
-    <SettingsDialog bind:settings />
+    <SettingsDialog bind:settings bind:open={settings_open} />
 </Dialog.Root>
 
 <div class="flex h-[100vh] flex-col justify-evenly">


### PR DESCRIPTION
# Audio Playback Fix in Settings Dialog

## Problem
The audio preview in the settings dialog continued playing even after the dialog was closed, leading to unintended background audio playback.

## Changes Made
- Added dialog open state tracking to `SettingsDialog.svelte`
- Implemented an effect to monitor dialog state and stop audio playback on close
- Added proper binding for the open state between parent and child components

closing #6